### PR TITLE
Add Github workflow to create release on new tag

### DIFF
--- a/.github/workflows/upload-on-tag.yaml
+++ b/.github/workflows/upload-on-tag.yaml
@@ -1,0 +1,35 @@
+name: Upload on new tags
+
+on:
+  push:
+    tags:
+      '*'
+
+jobs:
+  buildAndUpload:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        pip install scons markdown
+        sudo apt update
+        sudo apt install gettext
+    - name: Build add-on
+      run: scons version=`echo ${{ github.ref }}|rev|cut -d/ -f1|rev`
+    - name: Calculate sha256
+      run: sha256sum *.nvda-addon >> changelog.md
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        files: |
+          *.nvda-addon
+        body_path: changelog.md
+        prerelease: ${{ endsWith(github.ref, '-dev') }}


### PR DESCRIPTION
When pushing a new tag, a release will be created, with the nvda-addon file.
The content of changelog.md will be added as the release description with the SHA sum of the nvda-addon file.
If the tag name ends with -dev, it will create a pre-release.
