### PR TITLE
Allow to exit table navigation layer even when cursor is not in a table.

### DIFF
--- a/addon/globalPlugins/easyTableNavigator.py
+++ b/addon/globalPlugins/easyTableNavigator.py
@@ -90,21 +90,21 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		category=_("Easy Table Navigator")
 	)
 	def script_toggleTableNav(self, gesture):
-		if not tableNavAvailable():
-			# Translators: presented when a user is not in a table.
-			ui.message(_("Not in a table"))
+		if not self.tableNav:
+			if not tableNavAvailable():
+				# Translators: presented when a user is not in a table.
+				ui.message(_("Not in a table"))
+				return
+			self.tableNav = True
+			self.bindTableNavGestures()
+			# Translators: presented when table navigator layer is on.
+			ui.message(_("Table navigator on"))
 		else:
-			if not self.tableNav:
-				self.tableNav = True
-				self.bindTableNavGestures()
-				# Translators: presented when table navigator layer is on.
-				ui.message(_("Table navigator on"))
-			else:
-				self.tableNav = False
-				self.clearGestureBindings()
-				self.bindGestures(self.__gestures)
-				# Translators: presented when table navigator layer is off.
-				ui.message(_("Table navigator off"))
+			self.tableNav = False
+			self.clearGestureBindings()
+			self.bindGestures(self.__gestures)
+			# Translators: presented when table navigator layer is off.
+			ui.message(_("Table navigator off"))
 
 	# Some utility functions.
 	def bindTableNavGestures(self):


### PR DESCRIPTION
Hi Corentin

### Issue
#### STR
* Go to a table, e.g. on a webpage
* Activate table nav layer
* Press H to go to a header out of the table
* Try to exit table nav layer
#### Actual result
Cannot exit table nav layer with the following message: "Not in a table"
#### Expected result:
Exit table nav layer

### Solution
Rewrite the logic of table nav layer switch command by switching some if/else blocks
