### PR TITLE
Added extended table navigation commands and commands to read by row or column

### DIFF
--- a/addon/globalPlugins/easyTableNavigator/__init__.py
+++ b/addon/globalPlugins/easyTableNavigator/__init__.py
@@ -125,6 +125,29 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		self.bindGesture("kb:leftarrow", "prevColumn")
 		self.bindGesture("kb:downarrow", "nextRow")
 		self.bindGesture("kb:uparrow", "prevRow")
+		if not hasattr(documentBase.DocumentWithTableNavigation, 'script_firstRow'):
+			# In NVDA 2022.2, table navigation commands to jump to first/last row/column have been added.
+			# For previous versions of NVDA not supporting them, just return here.
+			return
+		self.bindGesture("kb:control+rightarrow", "lastColumn")
+		self.bindGesture("kb:end", "lastColumn")
+		self.bindGesture("kb:control+leftarrow", "firstColumn")
+		self.bindGesture("kb:home", "firstColumn")
+		self.bindGesture("kb:control+downarrow", "lastRow")
+		self.bindGesture("kb:pageDown", "lastRow")
+		self.bindGesture("kb:control+uparrow", "firstRow")
+		self.bindGesture("kb:pageUp", "firstRow")
+		if not hasattr(documentBase.DocumentWithTableNavigation, 'script_speakRow'):
+			# In NVDA 2022.4, new table navigation commands have been added:
+			# read entire row/column and say all in row/column.
+			# For previous versions of NVDA not supporting them, just return here.
+			return
+		self.bindGesture("kb:NVDA+rightarrow", "sayAllRow")
+		self.bindGesture("kb:NVDA+downarrow", "sayAllColumn")
+		self.bindGesture("kb:NVDA+leftarrow", "speakRow")
+		self.bindGesture("kb:NVDA+uparrow", "speakColumn")
+		
+				
 
 	# Table navigation commands.
 	
@@ -149,5 +172,29 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 
 	def script_prevColumn(self, gesture):
 		self.tableNavigationHelper(gesture, 'previousColumn')
+	
+	def script_lastRow(self, gesture):
+		self.tableNavigationHelper(gesture, 'lastRow')
 
+	def script_firstRow(self, gesture):
+		self.tableNavigationHelper(gesture, 'firstRow')
+
+	def script_lastColumn(self, gesture):
+		self.tableNavigationHelper(gesture, 'lastColumn')
+
+	def script_firstColumn(self, gesture):
+		self.tableNavigationHelper(gesture, 'firstColumn')
+	
+	def script_sayAllRow(self, gesture):
+		self.tableNavigationHelper(gesture, 'sayAllRow')
+	
+	def script_sayAllColumn(self, gesture):
+		self.tableNavigationHelper(gesture, 'sayAllColumn')
+	
+	def script_speakRow(self, gesture):
+		self.tableNavigationHelper(gesture, 'speakRow')
+		
+	def script_speakColumn(self, gesture):
+		self.tableNavigationHelper(gesture, 'speakColumn')
+	
 	__gestures = {}

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,12 @@
 * Download [development version][2]
 * NVDA compatibility: 2019.3 and beyond
 
-This plugin adds a layer command to use arrow keys to navigate table cells.
+This plugin adds a layer command to use simplified key combination to navigate table cells.
+When the layered commands are enabled, you can perform the following actions:
+- Navigate to the previous or next cell horizontally or vertically using arrow keys
+- Navigate to the first or last cell of the row or the column using control+arrow keys or Home, End, PageUp and PageDown
+- Read the whole row or column without moving the system caret using NVDA+leftArrow / NVDA+upArrow
+- Read the row or column starting from the current cell using NVDA+rightArrow / NVDA+downArrow
 
 Currently supported tables are:
 


### PR DESCRIPTION
Fixes #9 
Fixes #12 

This PR adds to Easy Table Navigator the new commands that have appeared in NVDA 2022.2 and NVDA 2022.4.

When the ETN layer is enabled the following commands are available for NVDA versions supporting them:
* home/end/pgUp/pgDown to jump to start/end of row/column
* control+left/right/up/downArrow to jump to start/end of row/column (alternative shortcut key for the same result)
* NVDA+left/up to read the whole row/column starting from the first cell without moving the current position of the cursor
* NVDA+right/down for sayAll in row/column, i.e. read the cells of the current row/column, starting from the current cell and moving the cursor's position while reading until the last cell of the row/column.

