### PR TITLE
Remap keys due to conflict

### DIFF
--- a/addon/globalPlugins/easyTableNavigator/__init__.py
+++ b/addon/globalPlugins/easyTableNavigator/__init__.py
@@ -142,10 +142,10 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			# read entire row/column and say all in row/column.
 			# For previous versions of NVDA not supporting them, just return here.
 			return
-		self.bindGesture("kb:NVDA+rightarrow", "sayAllRow")
-		self.bindGesture("kb:NVDA+downarrow", "sayAllColumn")
-		self.bindGesture("kb:NVDA+leftarrow", "speakRow")
-		self.bindGesture("kb:NVDA+uparrow", "speakColumn")
+		self.bindGesture("kb:windows+rightarrow", "sayAllRow")
+		self.bindGesture("kb:windows+downarrow", "sayAllColumn")
+		self.bindGesture("kb:windows+leftarrow", "speakRow")
+		self.bindGesture("kb:windows+uparrow", "speakColumn")
 		
 				
 

--- a/readme.md
+++ b/readme.md
@@ -9,8 +9,8 @@ This plugin adds a layer command to use simplified key combination to navigate t
 When the layered commands are enabled, you can perform the following actions:
 - Navigate to the previous or next cell horizontally or vertically using arrow keys
 - Navigate to the first or last cell of the row or the column using control+arrow keys or Home, End, PageUp and PageDown
-- Read the whole row or column without moving the system caret using NVDA+leftArrow / NVDA+upArrow
-- Read the row or column starting from the current cell using NVDA+rightArrow / NVDA+downArrow
+- Read the whole row or column without moving the system caret using windows+leftArrow / windows+upArrow
+- Read the row or column starting from the current cell using windows+rightArrow / windows+downArrow
 
 Currently supported tables are:
 


### PR DESCRIPTION
### Issue
When navigating table with table layer active, it was often useful to read the current line to re-read the first line of the cell. However NVDA+upArrow which is NVDA command to read the current line is now used in the table layer to read the whole column.

### Solution
Remapped the shortcut keys in the table nav layer to avoid using NVDA key:
- NVDA+upArrow/leftArrow becomes windows+upArrow/leftArrow (to read full column/row)
- NVDA+downArrow/rightArrow becomes windows+downArrow/rightArrow (say all in column/row)

Windows+arrows are windows shortcuts to maximize, minimize or snap the window somewhere; I do not expect these shortcuts to be frequently used while being in table nav layer.

### Known issue
The previous key mapping was quite easy to remember since for all NVDA table navigation (out of the table layer), you just needed to remove control and alt modifier to obtain the corresponding shortcut key in the table navigation layer. With this PR, this is no more the case.

I guess however that the possibility to read the current line without exiting table nav layer is more interesting.

