### PR TITLE
Add missing import

### DIFF
--- a/addon/globalPlugins/easyTableNavigator/__init__.py
+++ b/addon/globalPlugins/easyTableNavigator/__init__.py
@@ -15,6 +15,7 @@ from . import compa
 import controlTypes
 import ui
 import scriptHandler
+from comtypes import COMError
 import addonHandler
 addonHandler.initTranslation()
 controlTypes = compa.convertControlTypes(controlTypes)


### PR DESCRIPTION
Hi Corentin

Here is a little fix for a likely rare error.

### Issue
I have had the following error

```
ERROR - eventHandler.executeEvent (23:28:53.008) - MainThread (1424):
error executing event: gainFocus on <NVDAObjects.Dynamic_EditableTextLogContainerOutlookWordDocumentWordDocumentIAccessibleWindowNVDAObject object at 0x09141810> with extra args of {}
Traceback (most recent call last):
  File "C:\Users\Cyrille\AppData\Roaming\nvda\addons\easyTableNavigator\globalPlugins\easyTableNavigator\__init__.py", line 43, in _MSWordTableNavAvailable
    table=info._rangeObj.tables[1]
  File "monkeyPatches\comtypesMonkeyPatches.pyc", line 87, in new__getattr__
  File "comtypes\client\lazybind.pyc", line 168, in __getattr__
  File "comtypes\automation.pyc", line 747, in _invoke
  File "comtypes\automation.pyc", line 441, in _get_value
  File "comtypes\client\dynamic.pyc", line 29, in Dispatch
  File "comtypes\automation.pyc", line 716, in GetTypeInfo
  File "monkeyPatches\comtypesMonkeyPatches.pyc", line 158, in newGetTypeInfo
  File "monkeyPatches\comtypesMonkeyPatches.pyc", line 39, in __call__
exceptions.CallCancelled: COM call cancelled

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "eventHandler.pyc", line 325, in executeEvent
  File "eventHandler.pyc", line 115, in __init__
  File "eventHandler.pyc", line 124, in next
  File "C:\Users\Cyrille\AppData\Roaming\nvda\addons\easyTableNavigator\globalPlugins\easyTableNavigator\__init__.py", line 90, in event_gainFocus
    if tableNavAvailable(obj) and self.tableNav:
  File "C:\Users\Cyrille\AppData\Roaming\nvda\addons\easyTableNavigator\globalPlugins\easyTableNavigator\__init__.py", line 70, in tableNavAvailable
    return testFunc(focus)
  File "C:\Users\Cyrille\AppData\Roaming\nvda\addons\easyTableNavigator\globalPlugins\easyTableNavigator\__init__.py", line 44, in _MSWordTableNavAvailable
    except COMError:
NameError: name 'COMError' is not defined

```

### Solution
Add the missing import.

### Additional note
It's probably not a common code path, since it's the first time I have seen this error.
